### PR TITLE
Update page 1 via polling, instantly update wallet transactions upon sending one

### DIFF
--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -5,7 +5,10 @@
     </div>
     <Input
       v-model="passphrase"
-      :rules="[val => !!val || (val && val.length <= 0) || 'Required', val => validatePassphrase(val) || 'Must be a 12 word BIP39 mnemonic']"
+      :rules="[
+        val => !!val || (val && val.length <= 0) || 'Required',
+        val => validatePassphrase(val) || 'Must be a 12 word BIP39 mnemonic',
+      ]"
     />
   </ConfirmationModal>
   <div class="flex flex-wrap flex-gap mb-2">
@@ -246,6 +249,9 @@ export default {
     const confirmationRef = ref(null);
     const passphrase = ref(null);
 
+    const validatePassphrase = val =>
+      store.client.value.validatePassphrase(val);
+
     const confirmationModal = async () => {
       try {
         const { minTransactionFees } = await store.client.value.getMinFees();
@@ -262,8 +268,11 @@ export default {
           if (!passphrase.value)
             throw new Error('Passphrase should be present');
 
-          if (!store.client.value.validatePassphrase(passphrase.value))
-            throw new Error('Passphrase should be a valid 12 word BIP39 mnemonic');
+          if (!validatePassphrase(passphrase.value)) {
+            throw new Error(
+              'Passphrase should be a valid 12 word BIP39 mnemonic',
+            );
+          }
 
           const registerTxn = await store.client.value.prepareRegisterForgingDetails(
             {
@@ -312,7 +321,7 @@ export default {
           data,
         }),
       transformMonetaryUnit: _transformMonetaryUnit,
-      validatePassphrase: val => store.client.value.validatePassphrase(val),
+      validatePassphrase,
       networkSymbol: store.state.config.networkSymbol,
       confirmationRef,
       confirmationModal,

--- a/src/components/modals/TransferModal.vue
+++ b/src/components/modals/TransferModal.vue
@@ -161,6 +161,8 @@ export default {
           });
 
           await store.client.value.postTransaction(preparedTxn);
+
+          window.dispatchEvent(new Event('DataTable:update'));
         } catch (e) {
           store.notify({ message: `Error: ${e.message}`, error: true }, 5);
           error.value = true;


### PR DESCRIPTION
reintroduce poll on page 1
rename `pollerFn` to `setProgressbarAndGetData`
add event for instant update of transactions in wallet
improve `validatePassphrase` logic

@jondubois I did the polling discretely, that is that the progress bar on top isn't showing during active requests, let's discuss if this is okay.